### PR TITLE
Change backend example to use new hashing API

### DIFF
--- a/src/Backend.md
+++ b/src/Backend.md
@@ -86,7 +86,7 @@ This module needs an `add` function, which takes a value, hashes it, stores the 
 
 ```ocaml
   let add (prefix, client) value =
-      let hash = K.digest (Irmin.Type.to_string V.t value) in
+      let hash = K.hash (fun f -> f @@ Irmin.Type.to_string V.t value) in
       let key = Irmin.Type.to_string K.t hash in
       let value = Irmin.Type.to_string V.t value in
       ignore (Client.run client [| "SET"; prefix ^ key; value |]);


### PR DESCRIPTION
The Irmin hashing API was recently changed: mirage/irmin#751.

This change makes the tutorial consistent with Irmin/master. It might warrant some additional explanation in the surrounding body text; I'll let you be the judge of that :smile: